### PR TITLE
orjson 3.8.8

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,7 @@
 rust_compiler_version:
   - 1.64.0
-macos_min_version:
-  - 11.13  # [osx and arm64]
+# orjson has wheels only for MacOS SDK 11.0, see https://pypi.org/project/orjson/3.8.8/#files
 MACOSX_DEPLOYMENT_TARGET:
-  - 11.3  # [osx and arm64]
+  - 11.0  # [osx and arm64]
 MACOSX_SDK_VERSION:
-  - "11.3"                 # [osx and arm64]
-CONDA_BUILD_SYSROOT:
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx and arm64]
+  - "11.0"                 # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,10 @@
 rust_compiler_version:
   - 1.64.0
+macos_min_version:
+  - 11.13  # [osx and arm64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 11.3  # [osx and arm64]
+MACOSX_SDK_VERSION:
+  - "11.3"                 # [osx and arm64]
+CONDA_BUILD_SYSROOT:
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # There is no gnu version of orjson on Windows
 # because the simdutf8 does not get properly linked
 {% set name = "orjson" %}
-{% set version = "3.8.9" %}
+{% set version = "3.8.8" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c40bece58c11cb09aff17424d21b41f6f767d2b1252b2f745ec3ff29cce6a240
+  sha256: c096d7a523bae6ffb9c4a228ba4691d66113f0f2231579dc945523fbef09c6da
 
 build:
   number: 0
@@ -25,7 +25,6 @@ requirements:
     - maturin 0.13.7
     - python
     - pip
-    - setuptools
     - toml
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # There is no gnu version of orjson on Windows
 # because the simdutf8 does not get properly linked
 {% set name = "orjson" %}
-{% set version = "3.7.8" %}
+{% set version = "3.8.8" %}
 
 package:
   name: {{ name|lower }}
@@ -9,11 +9,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a2e824220245323bb3291bb10ccf2ba936ed0b14e5e4a6260a1d1ed048caf77e
+  sha256: c096d7a523bae6ffb9c4a228ba4691d66113f0f2231579dc945523fbef09c6da
 
 build:
   number: 0
-  skip: true  # [py<37 or (osx and arm64) or s390x]
+  skip: true  # [py<37 or s390x]
 
 requirements:
   build:
@@ -22,7 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - cargo-bundle-licenses
   host:
-    - maturin >=0.13,<0.14
+    - maturin 0.13.7
     - python
     - pip
     - toml
@@ -35,8 +35,10 @@ test:
     - orjson
   requires:
     - pip
+    - mypy
   commands:
     - pip check
+    - mypy -m orjson
 
 about:
   home: https://github.com/ijl/orjson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # There is no gnu version of orjson on Windows
 # because the simdutf8 does not get properly linked
 {% set name = "orjson" %}
-{% set version = "3.8.8" %}
+{% set version = "3.8.9" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c096d7a523bae6ffb9c4a228ba4691d66113f0f2231579dc945523fbef09c6da
+  sha256: c40bece58c11cb09aff17424d21b41f6f767d2b1252b2f745ec3ff29cce6a240
 
 build:
   number: 0
@@ -25,6 +25,7 @@ requirements:
     - maturin 0.13.7
     - python
     - pip
+    - setuptools
     - toml
     - wheel
   run:


### PR DESCRIPTION
Changelog: https://github.com/ijl/orjson/blob/master/CHANGELOG.md
Requirements:
- https://github.com/ijl/orjson/blob/3.8.8/pyproject.toml
- https://github.com/ijl/orjson/blob/3.8.8/requirements.txt

Actions:
1. Fix `MacOS SDK` version as **11.0** because orjson hasn't wheels for `11.1`, see https://pypi.org/project/orjson/3.8.8/#files
2. Pin `maturin` in `host`
3. Add `mypy` command

Notes:
- Seems like the next version **3.8.9** (the latest) will be **yanked**, see https://github.com/ijl/orjson/issues/370#issuecomment-1491404848