### PR TITLE
Pkg 4296 - update to 3.9.15 - CVE 2024

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,6 @@
+# Rust version requirement in upstream README.md
 rust_compiler_version:
-  - 1.64.0
+  - 1.76.0
 # orjson has wheels only for MacOS SDK 11.0, see https://pypi.org/project/orjson/3.8.8/#files
 MACOSX_DEPLOYMENT_TARGET:
   - 11.0  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # There is no gnu version of orjson on Windows
 # because the simdutf8 does not get properly linked
 {% set name = "orjson" %}
-{% set version = "3.9.10" %}
+{% set version = "3.9.15" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9ebbdbd6a046c304b1845e96fbcc5559cd296b4dfd3ad2509e33c4d9ce07d6a1
+  sha256: 95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4295](https://anaconda.atlassian.net/browse/PKG-4295) 
- [Upstream repository](https://github.com/ijl/orjson)
- [Upstream changelog/diff](https://github.com/ijl/orjson/compare/3.9.10...3.9.15)

### Explanation of changes:

- Version bump
- Update rust version as per upstream README


[PKG-4295]: https://anaconda.atlassian.net/browse/PKG-4295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ