### PR TITLE
Pkg 4295 - update to 3.9.15 - CVE 2024

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,8 +2,9 @@ rust_compiler_version:
   - 1.76.0
 # orjson has wheels only for MacOS SDK 11.0, see https://pypi.org/project/orjson/3.8.8/#files
 MACOSX_DEPLOYMENT_TARGET:
-  - 10.12  # [osx and arm64]
+  - 11.0  # [osx and arm64]
 MACOSX_SDK_VERSION:
-  - "10.12"                 # [osx and arm64]
+  - "11.0"                 # [osx and arm64]
+# https://github.com/rust-lang/rust/pull/104385
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.12.sdk        # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,9 @@
 rust_compiler_version:
-  - 1.64.0
+  - 1.76.0
 # orjson has wheels only for MacOS SDK 11.0, see https://pypi.org/project/orjson/3.8.8/#files
 MACOSX_DEPLOYMENT_TARGET:
-  - 11.0  # [osx and arm64]
+  - 10.12  # [osx and arm64]
 MACOSX_SDK_VERSION:
-  - "11.0"                 # [osx and arm64]
+  - "10.12"                 # [osx and arm64]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.12.sdk        # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # There is no gnu version of orjson on Windows
 # because the simdutf8 does not get properly linked
 {% set name = "orjson" %}
-{% set version = "3.9.10" %}
+{% set version = "3.9.15" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9ebbdbd6a046c304b1845e96fbcc5559cd296b4dfd3ad2509e33c4d9ce07d6a1
+  sha256: 95cae920959d772f30ab36d3b25f83bb0f3be671e986c72ce22f8fa700dae061
 
 build:
   number: 0


### PR DESCRIPTION
orjson 3.9.15

defaults

### Links

- [PKG-4295](https://anaconda.atlassian.net/browse/PKG-4295)
- [Upstream repository](https://github.com/ijl/orjson/tree/3.9.15)
- [Upstream changelog/diff](https://github.com/ijl/orjson/blob/3.9.15/CHANGELOG.md)

### Explanation of changes:

- Update version
- Update rust compiler version and `osx` compiler


[PKG-4295]: https://anaconda.atlassian.net/browse/PKG-4295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ